### PR TITLE
feat: add sidebar layout for SPA navigation

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,43 +1,45 @@
 <script setup lang="ts">
-import { onMounted } from 'vue';
-import { RouterView } from 'vue-router';
-import Header from '@/components/layout/Header.vue';
-import Footer from '@/components/layout/Footer.vue';
-import { useUserStore } from '@/stores/userStore';
-import { checkAuthStatus } from '@/services/auth';
+import { onMounted } from 'vue'
+import { RouterView } from 'vue-router'
+import Header from '@/components/layout/Header.vue'
+import Footer from '@/components/layout/Footer.vue'
+import Sidebar from '@/components/layout/Sidebar.vue'
+import { useUserStore } from '@/stores/userStore'
+import { checkAuthStatus } from '@/services/auth'
 
-const userStore = useUserStore();
+const userStore = useUserStore()
 
 onMounted(async () => {
-  console.log('🔄 Vérification de l\'authentification au démarrage...');
+  console.log('🔄 Vérification de l\'authentification au démarrage...')
 
-  userStore.setLoading(true);
+  userStore.setLoading(true)
 
   try {
-    const authStatus = await checkAuthStatus();
+    const authStatus = await checkAuthStatus()
 
     if (authStatus.isAuthenticated) {
-      console.log('✅ Utilisateur authentifié:', authStatus.user);
-      userStore.setUser(authStatus.user);
+      console.log('✅ Utilisateur authentifié:', authStatus.user)
+      userStore.setUser(authStatus.user)
     } else {
-      console.log('ℹ️ Utilisateur non authentifié');
-      userStore.logout();
+      console.log('ℹ️ Utilisateur non authentifié')
+      userStore.logout()
     }
   } catch (error) {
-    console.warn('⚠️ Erreur lors de la vérification d\'authentification:', error);
-    userStore.logout();
+    console.warn('⚠️ Erreur lors de la vérification d\'authentification:', error)
+    userStore.logout()
   }
-});
+})
 </script>
 
 <template>
-  <div class="h-screen grid grid-rows-[auto_1fr_auto] bg-background text-default">
-    <Header />
-
-    <main class="overflow-auto p-4">
-      <RouterView />
-    </main>
-
-    <Footer />
+  <div class="h-screen flex bg-background text-default">
+    <Sidebar />
+    <div class="flex flex-col flex-1">
+      <Header />
+      <main class="flex-1 overflow-auto p-4">
+        <RouterView />
+      </main>
+      <Footer />
+    </div>
   </div>
 </template>

--- a/frontend/src/components/layout/Header.vue
+++ b/frontend/src/components/layout/Header.vue
@@ -1,83 +1,14 @@
 <template>
-  <header class="flex items-center justify-between p-4 text-default">
-    <router-link to="/" class="picture focus:outline-none focus:ring-0">
-      <img :src=logo alt="Logo" class="image">
-    </router-link>
-    <nav>
-      <ul class="flex items-center space-x-6" v-if="userStore.isLoading">
-        <li>
-          <div class="cursor-default text-secondary opacity-50">
-            Chargement...
-          </div>
-        </li>
-      </ul>
-      <ul class="flex items-center space-x-6" v-else-if="userStore.isAuthenticated">
-        <li>
-          <button class="cursor-pointer text-secondary hover:text-accent transition-colors">
-            <router-link to="/add">add player</router-link>
-
-          </button>
-        </li>
-        <li>
-          <button class="cursor-pointer text-secondary hover:text-accent transition-colors">
-            <router-link to="/list">player list</router-link>
-
-          </button>
-        </li>
-        <li>
-          <button @click="logoutWithDiscord"
-                  class="cursor-pointer text-secondary hover:text-accent transition-colors">
-            Deconnexion
-          </button>
-        </li>
-      </ul>
-      <ul class="flex items-center space-x-6" v-else>
-        <li>
-          <button @click="loginWithDiscord"
-                  class="cursor-pointer text-secondary hover:text-accent transition-colors">
-            Connexion
-          </button>
-        </li>
-      </ul>
-    </nav>
+  <header class="flex items-center justify-center p-4 text-default">
+    <RouterLink to="/" class="picture focus:outline-none focus:ring-0">
+      <img :src="logo" alt="Logo" class="image" />
+    </RouterLink>
   </header>
 </template>
 
 <script setup lang="ts">
-import { redirectToDiscordAuth } from '@/services/auth';
+import { RouterLink } from 'vue-router'
 import logo from '@/assets/image/logo.png'
-import { useUserStore } from '@/stores/userStore';
-
-const userStore = useUserStore();
-
-function loginWithDiscord() {
-  try {
-    redirectToDiscordAuth();
-  } catch (error) {
-    console.error('Erreur lors de la redirection Discord:', error);
-  }
-}
-
-async function logoutWithDiscord() {
-  try {
-    const response = await fetch('/api/logout', {
-      method: 'GET',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-
-    if (response.ok) {
-      console.log('Déconnexion réussie');
-      userStore.logout();
-    } else {
-      console.error('Erreur lors de la déconnexion, status:', response.status);
-    }
-  } catch (error) {
-    console.error('Erreur lors de la déconnexion :', error);
-  }
-}
 </script>
 
 <style scoped>
@@ -85,21 +16,6 @@ async function logoutWithDiscord() {
   max-width: clamp(3rem, 15vw, 6rem);
   height: auto;
   object-fit: contain;
-}
-
-button {
-  font-weight: 500;
-  border: none;
-  outline: none;
-}
-
-button:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-}
-
-button:active {
-  transform: translateY(0);
 }
 
 @media (max-width: 480px) {

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -1,0 +1,89 @@
+<template>
+  <aside class="flex flex-col h-full w-56 bg-primary text-default">
+    <div class="p-4 text-xl font-bold">
+      <RouterLink to="/" class="block">GuildeTracker</RouterLink>
+    </div>
+    <nav class="flex-1 overflow-y-auto">
+      <ul v-if="userStore.isLoading" class="p-2">
+        <li class="text-secondary">Chargement...</li>
+      </ul>
+      <ul v-else-if="userStore.isAuthenticated" class="space-y-2 p-2">
+        <li>
+          <RouterLink
+            to="/add"
+            class="block px-3 py-2 rounded hover:bg-accent hover:text-background"
+          >
+            Ajouter un joueur
+          </RouterLink>
+        </li>
+        <li>
+          <RouterLink
+            to="/list"
+            class="block px-3 py-2 rounded hover:bg-accent hover:text-background"
+          >
+            Liste des joueurs
+          </RouterLink>
+        </li>
+      </ul>
+      <ul v-else class="p-2">
+        <li>
+          <button
+            @click="loginWithDiscord"
+            class="w-full text-left px-3 py-2 rounded hover:bg-accent hover:text-background"
+          >
+            Connexion
+          </button>
+        </li>
+      </ul>
+    </nav>
+    <div v-if="userStore.isAuthenticated && !userStore.isLoading" class="p-4 border-t border-secondary">
+      <button
+        @click="logoutWithDiscord"
+        class="w-full text-left px-3 py-2 rounded hover:bg-accent hover:text-background"
+      >
+        Déconnexion
+      </button>
+    </div>
+  </aside>
+</template>
+
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import { redirectToDiscordAuth } from '@/services/auth'
+import { useUserStore } from '@/stores/userStore'
+
+const userStore = useUserStore()
+
+function loginWithDiscord() {
+  try {
+    redirectToDiscordAuth()
+  } catch (error) {
+    console.error('Erreur lors de la redirection Discord:', error)
+  }
+}
+
+async function logoutWithDiscord() {
+  try {
+    const response = await fetch('/api/logout', {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+
+    if (response.ok) {
+      console.log('Déconnexion réussie')
+      userStore.logout()
+    } else {
+      console.error('Erreur lors de la déconnexion, status:', response.status)
+    }
+  } catch (error) {
+    console.error('Erreur lors de la déconnexion :', error)
+  }
+}
+</script>
+
+<style scoped>
+</style>
+


### PR DESCRIPTION
## Summary
- add sidebar with auth-aware navigation
- simplify header to logo only
- restructure app layout to integrate sidebar and reduce scrolling

## Testing
- `npm run lint` *(fails: multiple existing lint errors)*
- `npm run build` *(fails: missing localhost+2-key.pem in Vite config)*

------
https://chatgpt.com/codex/tasks/task_e_68b2084b12808329861e205e1a1b517c