### PR TITLE
refactor: streamline views for compact UX

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,43 +1,45 @@
 <script setup lang="ts">
-import { onMounted } from 'vue';
-import { RouterView } from 'vue-router';
-import Header from '@/components/layout/Header.vue';
-import Footer from '@/components/layout/Footer.vue';
-import { useUserStore } from '@/stores/userStore';
-import { checkAuthStatus } from '@/services/auth';
+import { onMounted } from 'vue'
+import { RouterView } from 'vue-router'
+import Header from '@/components/layout/Header.vue'
+import Footer from '@/components/layout/Footer.vue'
+import Sidebar from '@/components/layout/Sidebar.vue'
+import { useUserStore } from '@/stores/userStore'
+import { checkAuthStatus } from '@/services/auth'
 
-const userStore = useUserStore();
+const userStore = useUserStore()
 
 onMounted(async () => {
-  console.log('🔄 Vérification de l\'authentification au démarrage...');
+  console.log('🔄 Vérification de l\'authentification au démarrage...')
 
-  userStore.setLoading(true);
+  userStore.setLoading(true)
 
   try {
-    const authStatus = await checkAuthStatus();
+    const authStatus = await checkAuthStatus()
 
     if (authStatus.isAuthenticated) {
-      console.log('✅ Utilisateur authentifié:', authStatus.user);
-      userStore.setUser(authStatus.user);
+      console.log('✅ Utilisateur authentifié:', authStatus.user)
+      userStore.setUser(authStatus.user)
     } else {
-      console.log('ℹ️ Utilisateur non authentifié');
-      userStore.logout();
+      console.log('ℹ️ Utilisateur non authentifié')
+      userStore.logout()
     }
   } catch (error) {
-    console.warn('⚠️ Erreur lors de la vérification d\'authentification:', error);
-    userStore.logout();
+    console.warn('⚠️ Erreur lors de la vérification d\'authentification:', error)
+    userStore.logout()
   }
-});
+})
 </script>
 
 <template>
-  <div class="h-screen grid grid-rows-[auto_1fr_auto] bg-background text-default">
-    <Header />
-
-    <main class="overflow-auto p-4">
-      <RouterView />
-    </main>
-
-    <Footer />
+  <div class="h-screen flex bg-background text-default">
+    <Sidebar />
+    <div class="flex flex-col flex-1">
+      <Header />
+      <main class="flex-1 overflow-auto p-4">
+        <RouterView />
+      </main>
+      <Footer />
+    </div>
   </div>
 </template>

--- a/frontend/src/components/CharacterForm.vue
+++ b/frontend/src/components/CharacterForm.vue
@@ -364,7 +364,6 @@ type Signup = {
   roleName?: RoleName
   level?: number
 }
-type EventJson = { date?: string; signUps: Signup[] }
 
 const NON_PLAYABLE = new Set(['Bench', 'Absence', 'Tentative', 'Late'])
 
@@ -398,9 +397,9 @@ function parseJson() {
   if (!txt) return
 
   try {
-    const parsed = JSON.parse(txt) as EventJson | { signUps?: Signup[] }
-    const signUps = Array.isArray((parsed as any).signUps)
-      ? ((parsed as any).signUps as Signup[])
+    const parsed = JSON.parse(txt) as { signUps?: unknown }
+    const signUps = Array.isArray(parsed.signUps)
+      ? (parsed.signUps as Signup[])
       : []
 
     if (!signUps.length) {

--- a/frontend/src/components/EventJsonImportModal.vue
+++ b/frontend/src/components/EventJsonImportModal.vue
@@ -92,7 +92,7 @@ type Character = {
 
 const NON_PLAYABLE = new Set(['Bench', 'Absence', 'Tentative', 'Late'])
 
-const props = defineProps<{
+defineProps<{
   modelValue: boolean
 }>()
 const emit = defineEmits<{

--- a/frontend/src/components/Toaster.vue
+++ b/frontend/src/components/Toaster.vue
@@ -14,6 +14,7 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ name: 'AppToaster' })
 type ToastType = 'success' | 'error' | 'warning' | 'info'
 interface Notification {
   id: string

--- a/frontend/src/components/layout/Footer.vue
+++ b/frontend/src/components/layout/Footer.vue
@@ -35,6 +35,7 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ name: 'AppFooter' })
 </script>
 
 <style scoped>

--- a/frontend/src/components/layout/Header.vue
+++ b/frontend/src/components/layout/Header.vue
@@ -1,83 +1,15 @@
 <template>
-  <header class="flex items-center justify-between p-4 text-default">
-    <router-link to="/" class="picture focus:outline-none focus:ring-0">
-      <img :src=logo alt="Logo" class="image">
-    </router-link>
-    <nav>
-      <ul class="flex items-center space-x-6" v-if="userStore.isLoading">
-        <li>
-          <div class="cursor-default text-secondary opacity-50">
-            Chargement...
-          </div>
-        </li>
-      </ul>
-      <ul class="flex items-center space-x-6" v-else-if="userStore.isAuthenticated">
-        <li>
-          <button class="cursor-pointer text-secondary hover:text-accent transition-colors">
-            <router-link to="/add">add player</router-link>
-
-          </button>
-        </li>
-        <li>
-          <button class="cursor-pointer text-secondary hover:text-accent transition-colors">
-            <router-link to="/list">player list</router-link>
-
-          </button>
-        </li>
-        <li>
-          <button @click="logoutWithDiscord"
-                  class="cursor-pointer text-secondary hover:text-accent transition-colors">
-            Deconnexion
-          </button>
-        </li>
-      </ul>
-      <ul class="flex items-center space-x-6" v-else>
-        <li>
-          <button @click="loginWithDiscord"
-                  class="cursor-pointer text-secondary hover:text-accent transition-colors">
-            Connexion
-          </button>
-        </li>
-      </ul>
-    </nav>
+  <header class="flex items-center justify-center p-4 text-default">
+    <RouterLink to="/" class="picture focus:outline-none focus:ring-0">
+      <img :src="logo" alt="Logo" class="image" />
+    </RouterLink>
   </header>
 </template>
 
 <script setup lang="ts">
-import { redirectToDiscordAuth } from '@/services/auth';
+defineOptions({ name: 'AppHeader' })
+import { RouterLink } from 'vue-router'
 import logo from '@/assets/image/logo.png'
-import { useUserStore } from '@/stores/userStore';
-
-const userStore = useUserStore();
-
-function loginWithDiscord() {
-  try {
-    redirectToDiscordAuth();
-  } catch (error) {
-    console.error('Erreur lors de la redirection Discord:', error);
-  }
-}
-
-async function logoutWithDiscord() {
-  try {
-    const response = await fetch('/api/logout', {
-      method: 'GET',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-
-    if (response.ok) {
-      console.log('Déconnexion réussie');
-      userStore.logout();
-    } else {
-      console.error('Erreur lors de la déconnexion, status:', response.status);
-    }
-  } catch (error) {
-    console.error('Erreur lors de la déconnexion :', error);
-  }
-}
 </script>
 
 <style scoped>
@@ -85,21 +17,6 @@ async function logoutWithDiscord() {
   max-width: clamp(3rem, 15vw, 6rem);
   height: auto;
   object-fit: contain;
-}
-
-button {
-  font-weight: 500;
-  border: none;
-  outline: none;
-}
-
-button:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-}
-
-button:active {
-  transform: translateY(0);
 }
 
 @media (max-width: 480px) {

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -1,0 +1,90 @@
+<template>
+  <aside class="flex flex-col h-full w-56 bg-primary text-default">
+    <div class="p-4 text-xl font-bold">
+      <RouterLink to="/" class="block">GuildeTracker</RouterLink>
+    </div>
+    <nav class="flex-1 overflow-y-auto">
+      <ul v-if="userStore.isLoading" class="p-2">
+        <li class="text-secondary">Chargement...</li>
+      </ul>
+      <ul v-else-if="userStore.isAuthenticated" class="space-y-2 p-2">
+        <li>
+          <RouterLink
+            to="/add"
+            class="block px-3 py-2 rounded hover:bg-accent hover:text-background"
+          >
+            Ajouter un joueur
+          </RouterLink>
+        </li>
+        <li>
+          <RouterLink
+            to="/list"
+            class="block px-3 py-2 rounded hover:bg-accent hover:text-background"
+          >
+            Liste des joueurs
+          </RouterLink>
+        </li>
+      </ul>
+      <ul v-else class="p-2">
+        <li>
+          <button
+            @click="loginWithDiscord"
+            class="w-full text-left px-3 py-2 rounded hover:bg-accent hover:text-background"
+          >
+            Connexion
+          </button>
+        </li>
+      </ul>
+    </nav>
+    <div v-if="userStore.isAuthenticated && !userStore.isLoading" class="p-4 border-t border-secondary">
+      <button
+        @click="logoutWithDiscord"
+        class="w-full text-left px-3 py-2 rounded hover:bg-accent hover:text-background"
+      >
+        Déconnexion
+      </button>
+    </div>
+  </aside>
+</template>
+
+<script setup lang="ts">
+defineOptions({ name: 'AppSidebar' })
+import { RouterLink } from 'vue-router'
+import { redirectToDiscordAuth } from '@/services/auth'
+import { useUserStore } from '@/stores/userStore'
+
+const userStore = useUserStore()
+
+function loginWithDiscord() {
+  try {
+    redirectToDiscordAuth()
+  } catch (error) {
+    console.error('Erreur lors de la redirection Discord:', error)
+  }
+}
+
+async function logoutWithDiscord() {
+  try {
+    const response = await fetch('/api/logout', {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+
+    if (response.ok) {
+      console.log('Déconnexion réussie')
+      userStore.logout()
+    } else {
+      console.error('Erreur lors de la déconnexion, status:', response.status)
+    }
+  } catch (error) {
+    console.error('Erreur lors de la déconnexion :', error)
+  }
+}
+</script>
+
+<style scoped>
+</style>
+

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -2,13 +2,15 @@ import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 import AddPlayerView from '../views/AddPlayerView.vue'
 import ListPlayerView from '@/views/ListPlayerView.vue'
+import AssignementView from '../views/AssignementView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
-    {path: '/', name: 'home', component: HomeView},
-    {path: '/add', name: 'addPlayer', component: AddPlayerView},
-    {path: '/list', name: 'listPlayer', component: ListPlayerView},
+    { path: '/', name: 'home', component: HomeView },
+    { path: '/add', name: 'addPlayer', component: AddPlayerView },
+    { path: '/list', name: 'listPlayer', component: ListPlayerView },
+    { path: '/assignments', name: 'assignments', component: AssignementView },
   ],
 })
 

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -39,7 +39,8 @@ export async function logoutUser() {
     } else {
       return { success: false, error: `Status: ${response.status}` };
     }
-  } catch (error: any) {
-    return { success: false, error: error.message };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { success: false, error: message };
   }
 }

--- a/frontend/src/views/AddPlayerView.vue
+++ b/frontend/src/views/AddPlayerView.vue
@@ -1,30 +1,20 @@
 <template>
-  <div class="app">
-    <main class="app-main">
-      <div class="toolbar">
-        <button class="btn btn-outline" @click="showImport = true">Import JSON</button>
-      </div>
+  <section class="page">
+    <CharacterForm
+      form-title="Add character"
+      :enable-auto-validation="true"
+      @submit="handleCharacterSubmit"
+      @error="handleFormError"
+    />
 
-      <CharacterForm
-        form-title="Add character"
-        :enable-auto-validation="true"
-        @submit="handleCharacterSubmit"
-        @error="handleFormError"
-      />
-    </main>
-
-    <div class="notifications">
-      <div v-for="n in notifications" :key="n.id" class="notification" :class="n.type">
-        {{ n.message }}
-      </div>
-    </div>
-
-  </div>
+    <Toaster :items="notifications" />
+  </section>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import CharacterForm from '@/components/CharacterForm.vue'
+import Toaster from '@/components/Toaster.vue'
 import type {
   Character,
   FormSubmitEvent,
@@ -41,7 +31,6 @@ interface Notification {
 
 const characters = ref<Character[]>([])
 const notifications = ref<Notification[]>([])
-const showImport = ref(false)
 
 const genId = () => Date.now().toString(36) + Math.random().toString(36).slice(2)
 const toast = (m: string, t: ToastType = 'info') => {
@@ -103,69 +92,11 @@ onMounted(load)
 </script>
 
 <style scoped>
-.app-main {
+.page {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 2rem 2rem;
-}
-.toolbar {
-  display: flex;
-  justify-content: flex-end;
-  padding: 1rem 0;
-}
-.btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.6rem 1.1rem;
-  border-radius: 10px;
-  font-weight: 700;
-  cursor: pointer;
-  border: 1px solid #cbd5e1;
-  background: transparent;
-  color: #334155;
-}
-.btn:hover {
-  background: #f8fafc;
-}
-
-.notifications {
-  position: fixed;
-  top: 1rem;
-  right: 1rem;
-  z-index: 1000;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-}
-.notification {
-  padding: 1rem 1.25rem;
-  border-radius: 10px;
-  color: white;
-  font-weight: 600;
-  min-width: 300px;
-  animation: slideIn 0.25s ease;
-}
-.notification.success {
-  background: #10b981;
-}
-.notification.error {
-  background: #ef4444;
-}
-.notification.warning {
-  background: #f59e0b;
-}
-.notification.info {
-  background: #3b82f6;
-}
-@keyframes slideIn {
-  from {
-    transform: translateX(100%);
-    opacity: 0;
-  }
-  to {
-    transform: translateX(0);
-    opacity: 1;
-  }
+  gap: 1rem;
 }
 </style>

--- a/frontend/src/views/AssignementView.vue
+++ b/frontend/src/views/AssignementView.vue
@@ -1,12 +1,29 @@
 <script setup lang="ts">
-
 </script>
 
 <template>
-  <div>
-
-  </div>
+  <section class="page">
+    <h1 class="page-title">Assignments</h1>
+    <p class="placeholder">This section is under construction.</p>
+  </section>
 </template>
 
-<style scoped></style>
+<style scoped>
+.page {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.page-title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0;
+}
+.placeholder {
+  color: #64748b;
+}
+</style>
 

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,7 +1,50 @@
 <script setup lang="ts">
+import { RouterLink } from 'vue-router'
 </script>
 
 <template>
-  <main>
-  </main>
+  <section class="page home">
+    <h1 class="page-title">Dashboard</h1>
+    <div class="quick-links">
+      <RouterLink to="/list" class="nav-card">View Players</RouterLink>
+      <RouterLink to="/add" class="nav-card">Add Player</RouterLink>
+      <RouterLink to="/assignments" class="nav-card">Assignments</RouterLink>
+    </div>
+  </section>
 </template>
+
+<style scoped>
+.page {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+.page-title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0;
+}
+.quick-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+.nav-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  font-weight: 600;
+  color: #334155;
+  transition: background 0.2s;
+}
+.nav-card:hover {
+  background: #f8fafc;
+}
+</style>

--- a/frontend/src/views/ListPlayerView.vue
+++ b/frontend/src/views/ListPlayerView.vue
@@ -1,38 +1,35 @@
 <template>
-  <div class="app">
-    <main class="app-main">
-      <PlayersHeaderStats
-        :total="characters.length"
-        :tanks="getCharactersByRole('Tanks').length"
-        :healers="getCharactersByRole('Healers').length"
-        :dps="getDpsCount()"
+  <section class="page">
+    <PlayersHeaderStats
+      :total="characters.length"
+      :tanks="getCharactersByRole('Tanks').length"
+      :healers="getCharactersByRole('Healers').length"
+      :dps="getDpsCount()"
+    />
+
+    <PlayersFilters :classes="availableClasses" v-model="filters" @clear="clearFilters" />
+
+    <div v-if="filteredCharacters.length === 0" class="empty-state">
+      <div class="empty-content" role="status" aria-live="polite">
+        <span class="empty-icon">👤</span>
+        <h3>No characters found</h3>
+        <p v-if="characters.length === 0">You haven’t created any characters yet.</p>
+        <p v-else>No characters match the selected filters.</p>
+      </div>
+    </div>
+
+    <div v-else class="characters-grid">
+      <CharacterCard
+        v-for="c in filteredCharacters"
+        :key="c.id"
+        :character="c"
+        @edit="editCharacter"
+        @delete="deleteCharacter"
       />
+    </div>
 
-      <PlayersFilters :classes="availableClasses" v-model="filters" @clear="clearFilters" />
-
-      <div v-if="filteredCharacters.length === 0" class="empty-state">
-        <div class="empty-content" role="status" aria-live="polite">
-          <span class="empty-icon">👤</span>
-          <h3>No characters found</h3>
-          <p v-if="characters.length === 0">You haven’t created any characters yet.</p>
-          <p v-else>No characters match the selected filters.</p>
-        </div>
-      </div>
-
-      <div v-else class="characters-grid">
-        <CharacterCard
-          v-for="c in filteredCharacters"
-          :key="c.id"
-          :character="c"
-          @edit="editCharacter"
-          @delete="deleteCharacter"
-        />
-      </div>
-    </main>
-
-    <!-- Toaster -->
     <Toaster :items="notifications" />
-  </div>
+  </section>
 </template>
 
 <script setup lang="ts">
@@ -42,8 +39,7 @@ import PlayersFilters from '@/components/PlayersFilters.vue'
 import CharacterCard from '@/components/CharacterCard.vue'
 import Toaster from '@/components/Toaster.vue'
 
-import type { Character, Role } from '@/interfaces/game.interface'
-import { ROLE_ICONS } from '@/interfaces/game.interface'
+import type { Character } from '@/interfaces/game.interface'
 
 type ToastType = 'success' | 'error' | 'warning' | 'info'
 interface Notification {
@@ -73,15 +69,6 @@ const getCharactersByRole = (role: string) => characters.value.filter((c) => c.r
 
 const getDpsCount = () => getCharactersByRole('Melee').length + getCharactersByRole('Ranged').length
 
-const getRoleDisplay = (role: Role) => `${ROLE_ICONS[role]} ${role}`
-
-const formatDate = (dateString: string) =>
-  new Date(dateString).toLocaleDateString('en-GB', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
-
 const genId = () => Date.now().toString(36) + Math.random().toString(36).slice(2)
 
 const pushToast = (message: string, type: ToastType = 'info') => {
@@ -93,7 +80,7 @@ const pushToast = (message: string, type: ToastType = 'info') => {
   }, 3000)
 }
 
-const editCharacter = (c: Character) => {
+const editCharacter = () => {
   pushToast('Edit feature to be implemented.', 'info')
 }
 
@@ -138,14 +125,12 @@ onMounted(loadFromLocalStorage)
 </script>
 
 <style scoped>
-.app {
-  max-height: 100vh;
-  font-family: 'Inter', 'Segoe UI', sans-serif;
-}
-.app-main {
+.page {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 2rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .empty-state {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -33,14 +33,14 @@ export default defineConfig({
           console.log('🔄 Rewriting path:', path);
           return path;
         },
-        configure: (proxy, options) => {
-          proxy.on('proxyReq', (proxyReq, req, res) => {
+        configure: (proxy) => {
+          proxy.on('proxyReq', (proxyReq, req) => {
             console.log('🚀 Proxying request:', req.method, req.url, '-> https://localhost:443' + req.url);
           });
-          proxy.on('proxyRes', (proxyRes, req, res) => {
+          proxy.on('proxyRes', (proxyRes, req) => {
             console.log('📨 Proxy response:', proxyRes.statusCode, 'for', req.url);
           });
-          proxy.on('error', (err, req, res) => {
+          proxy.on('error', (err, req) => {
             console.error('❌ Proxy error:', err.message, 'for', req.url);
           });
         }


### PR DESCRIPTION
## Summary
- redesign home dashboard with quick links
- unify player views under compact page layout and toaster notifications
- add assignments placeholder and clean up lint issues

## Testing
- `npm run lint`
- `npm run build` *(fails: ENOENT no such file or directory, open 'localhost+2-key.pem')*


------
https://chatgpt.com/codex/tasks/task_e_68b2084b12808329861e205e1a1b517c