### PR TITLE
feat: improve responsive layout

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { onMounted, ref } from 'vue'
 import { RouterView } from 'vue-router'
 import Sidebar from '@/components/layout/Sidebar.vue'
 import { useUserStore } from '@/stores/userStore'
 import { checkAuthStatus } from '@/services/auth'
 
 const userStore = useUserStore()
+const sidebarOpen = ref(false)
+
+function toggleSidebar() {
+  sidebarOpen.value = !sidebarOpen.value
+}
 
 onMounted(async () => {
   console.log('🔄 Vérification de l\'authentification au démarrage...')
@@ -30,10 +35,40 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="h-screen flex bg-background text-default">
-    <Sidebar />
-    <main class="flex-1 overflow-auto p-4">
-      <RouterView />
-    </main>
+  <div class="min-h-screen flex bg-background text-default">
+    <div
+      v-if="sidebarOpen"
+      class="fixed inset-0 bg-black/50 z-40 md:hidden"
+      @click="sidebarOpen = false"
+    />
+    <Sidebar :open="sidebarOpen" @close="sidebarOpen = false" />
+
+    <div class="flex-1 flex flex-col">
+      <header
+        class="flex items-center gap-3 p-4 border-b border-secondary md:hidden"
+      >
+        <button
+          @click="toggleSidebar"
+          aria-label="Ouvrir le menu"
+          class="text-default"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            class="w-6 h-6"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+        <span class="font-bold">GuildeTracker</span>
+      </header>
+
+      <main class="flex-1 overflow-auto p-4">
+        <RouterView />
+      </main>
+    </div>
   </div>
 </template>

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -1,7 +1,26 @@
 <template>
-  <aside class="flex flex-col h-full w-56 bg-primary text-default">
-    <div class="p-4 text-xl font-bold">
+  <aside
+    class="flex flex-col h-full w-56 bg-primary text-default transform transition-transform duration-200 md:translate-x-0"
+    :class="open ? 'translate-x-0 fixed inset-y-0 left-0 z-50 md:static' : '-translate-x-full fixed inset-y-0 left-0 z-50 md:static md:translate-x-0'"
+  >
+    <div class="p-4 text-xl font-bold flex items-center justify-between">
       <RouterLink to="/" class="block">GuildeTracker</RouterLink>
+      <button
+        class="md:hidden"
+        @click="$emit('close')"
+        aria-label="Fermer le menu"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          class="w-5 h-5"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
     </div>
     <nav class="flex-1 overflow-y-auto">
       <ul v-if="userStore.isLoading" class="p-2">
@@ -74,6 +93,8 @@ import { RouterLink } from 'vue-router'
 import { redirectToDiscordAuth } from '@/services/auth'
 import { useUserStore } from '@/stores/userStore'
 
+const { open } = defineProps<{ open: boolean }>()
+defineEmits(['close'])
 const userStore = useUserStore()
 
 function loginWithDiscord() {

--- a/frontend/src/views/AddPlayerView.vue
+++ b/frontend/src/views/AddPlayerView.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="page">
+  <section class="max-w-screen-xl mx-auto flex flex-col gap-4 p-4">
     <CharacterForm
       form-title="Add character"
       :enable-auto-validation="true"
@@ -20,7 +20,6 @@ import type {
   Character,
   FormSubmitEvent,
   FormErrors,
-  CharacterStatus,
 } from '@/interfaces/game.interface'
 
 type ToastType = 'success' | 'error' | 'warning' | 'info'
@@ -107,11 +106,4 @@ onMounted(load)
 </script>
 
 <style scoped>
-.page {
-  max-width: 1200px;
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
 </style>

--- a/frontend/src/views/AssignementView.vue
+++ b/frontend/src/views/AssignementView.vue
@@ -2,28 +2,12 @@
 </script>
 
 <template>
-  <section class="page">
-    <h1 class="page-title">Assignments</h1>
-    <p class="placeholder">This section is under construction.</p>
+  <section class="max-w-screen-xl mx-auto flex flex-col gap-4 p-4">
+    <h1 class="text-2xl font-bold text-primary">Assignments</h1>
+    <p class="text-secondary">This section is under construction.</p>
   </section>
 </template>
 
 <style scoped>
-.page {
-  max-width: 1200px;
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-.page-title {
-  font-size: 1.8rem;
-  font-weight: 700;
-  color: #0f172a;
-  margin: 0;
-}
-.placeholder {
-  color: #64748b;
-}
 </style>
 

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,24 +1,11 @@
 <script setup lang="ts"></script>
 
 <template>
-  <section class="page home">
-    <h1 class="page-title">Dashboard</h1>
+  <section class="max-w-screen-xl mx-auto flex flex-col gap-6 p-4">
+    <h1 class="text-2xl font-bold text-primary">Dashboard</h1>
     <p>Bienvenue sur GuildeTracker.</p>
   </section>
 </template>
 
 <style scoped>
-.page {
-  max-width: 1200px;
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-.page-title {
-  font-size: 1.8rem;
-  font-weight: 700;
-  color: #0f172a;
-  margin: 0;
-}
 </style>

--- a/frontend/src/views/ListPlayerView.vue
+++ b/frontend/src/views/ListPlayerView.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="page">
+  <section class="max-w-screen-xl mx-auto flex flex-col gap-4 p-4">
     <PlayersHeaderStats
       :total="characters.length"
       :tanks="getCharactersByRole('Tanks').length"
@@ -9,16 +9,25 @@
 
     <PlayersFilters :classes="availableClasses" v-model="filters" @clear="clearFilters" />
 
-    <div v-if="filteredCharacters.length === 0" class="empty-state">
-      <div class="empty-content" role="status" aria-live="polite">
-        <span class="empty-icon">👤</span>
-        <h3>No characters found</h3>
-        <p v-if="characters.length === 0">You haven’t created any characters yet.</p>
-        <p v-else>No characters match the selected filters.</p>
+    <div
+      v-if="filteredCharacters.length === 0"
+      class="flex justify-center items-center min-h-[280px] p-8"
+      role="status"
+      aria-live="polite"
+    >
+      <div class="text-center max-w-md">
+        <span class="text-4xl mb-3 block">👤</span>
+        <h3 class="text-xl font-bold text-primary mb-2">No characters found</h3>
+        <p v-if="characters.length === 0" class="text-secondary">
+          You haven’t created any characters yet.
+        </p>
+        <p v-else class="text-secondary">
+          No characters match the selected filters.
+        </p>
       </div>
     </div>
 
-    <div v-else class="characters-grid">
+    <div v-else class="grid gap-5 p-5 sm:grid-cols-2 lg:grid-cols-3">
       <CharacterCard
         v-for="c in filteredCharacters"
         :key="c.id"
@@ -125,52 +134,4 @@ onMounted(loadFromLocalStorage)
 </script>
 
 <style scoped>
-.page {
-  max-width: 1200px;
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.empty-state {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 280px;
-  padding: 2rem;
-}
-.empty-content {
-  text-align: center;
-  max-width: 420px;
-}
-.empty-icon {
-  font-size: 3.2rem;
-  display: block;
-  margin-bottom: 0.75rem;
-}
-.empty-content h3 {
-  font-size: 1.3rem;
-  font-weight: 700;
-  color: #0f172a;
-  margin: 0 0 0.5rem 0;
-}
-.empty-content p {
-  color: #64748b;
-  margin: 0;
-}
-
-.characters-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 1.25rem;
-  padding: 1.25rem;
-}
-
-@media (max-width: 768px) {
-  .characters-grid {
-    grid-template-columns: 1fr;
-    padding: 1rem;
-  }
-}
 </style>


### PR DESCRIPTION
## Summary
- add mobile sidebar with toggle and overlay
- refactor main views with Tailwind responsive classes
- simplify layout for better UX on small screens

## Testing
- `npm run lint`
- `npm run build` *(fails: ENOENT: no such file or directory, open 'frontend/localhost+2-key.pem')*
- `npm run type-check` *(fails: TS2677: A type predicate's type must be assignable to its parameter's type)*

------
https://chatgpt.com/codex/tasks/task_e_68b212abe3108329a1de6612829132b6